### PR TITLE
Added glusterfs-fuse dependency

### DIFF
--- a/fusor-utils.spec
+++ b/fusor-utils.spec
@@ -10,6 +10,7 @@ Source1: safe-mount.sh
 Source2: safe-umount.sh
 
 BuildArch: noarch
+Requires: glusterfs-fuse
 
 %description
 Fusor Server Utilities


### PR DESCRIPTION
glusterfs-fuse is required when checking gluster mount points during the review process in the web UI. Since the safe-mount script calls the mount I am adding the dependency to fusor-utils.
