### PR TITLE
rpmdiff: dist should be ?dist

### DIFF
--- a/fusor-utils.spec
+++ b/fusor-utils.spec
@@ -1,7 +1,7 @@
 Summary: Fusor Server Utilities
 Name:    fusor-utils
 Version: 1.0.0
-Release: 0%{dist}
+Release: 0%{?dist}
 Group:   Applications/Internet 
 License: Distributable
 URL: https://github.com/fusor/fusor_utils


### PR DESCRIPTION
The dist tag should be of the form "%{?dist}", but instead found this:
Release: 3%{dist}
