### PR TITLE
1396267 - fix async mount validations

### DIFF
--- a/safe-mount.sh
+++ b/safe-mount.sh
@@ -4,42 +4,46 @@
 # that attempts to prevent things like whitespace.
 #
 # Usage:
-#  safe-mount.sh 123 www.example.com /nfs_share nfs
+#  safe-mount.sh 123 selfhosted www.example.com /nfs_share nfs
+#  safe-mount.sh <deploy id> <unique suffix> <host> <share path> <share type>
 
-kvm=36
-regex='[[:space:]]+'
+regex_contains_spaces='[[:space:]]+'
 
 if ! [[ "$1" =~ ^[0-9]+$ ]]; then
-  echo "Bad deployment id."
+  echo "Bad deployment id format. Numeric chars only."
   exit 1
 fi
 
-mount="/tmp/fusor-test-mount-$1"
-
-if [[ "$2" =~ $regex ]]; then
-  echo "Bad hostname format."
+if ! [[ "$2" =~ ^[a-z]+$ ]]; then
+  echo "Bad unique suffix format. Lowercase alphabet chars only."
   exit 1
 fi
 
-if [[ "$3" =~ $regex ]]; then
-  echo "Bad NFS share format."
+if [[ "$3" =~ $regex_contains_spaces ]]; then
+  echo "Bad hostname format. Spaces not allowed."
   exit 1
 fi
 
-if [[ "$4" =~ $regex ]]; then
-  echo "Bad mount type format."
+if [[ "$4" =~ $regex_contains_spaces ]]; then
+  echo "Bad NFS share format. Spaces not allowed."
   exit 1
 fi
 
-if [[ -z "$4" ]]; then
+if [[ "$5" =~ $regex_contains_spaces ]]; then
+  echo "Bad mount type format. Spaces not allowed."
+  exit 1
+fi
+
+if [[ -z "$5" ]]; then
   type='nfs'
 else
-  type="$4"
+  type="$5"
 fi
 
+mount="/tmp/fusor-test-mount-$1-$2"
 mkdir -p "$mount"
-safe-umount.sh $1 2> /dev/null # attempt to unmount any existing mount
-mount -r -t $type --target "$mount" --source "$2:$3"
+safe-umount.sh $1 $2 2> /dev/null # attempt to unmount any existing mount
+mount -r -t $type --target "$mount" --source "$3:$4"
 
 if [[ $? -ne 0 ]]; then
   echo "Failed to mount $4 share"
@@ -47,4 +51,3 @@ if [[ $? -ne 0 ]]; then
 else
   echo $mount
 fi
-

--- a/safe-umount.sh
+++ b/safe-umount.sh
@@ -4,14 +4,19 @@
 # that attempts to prevent things like unmounting other FSes
 #
 # Usage:
-#  safe-umount.sh 123
-
+#  safe-umount.sh 123 selfhosted
+#  safe-umount.sh <deploy id> <unique suffix>
 
 if ! [[ "$1" =~ ^[0-9]+$ ]]; then
   echo "Bad deployment id."
   exit 1
 fi
 
-mount="/tmp/fusor-test-mount-$1"
+if ! [[ "$2" =~ ^[a-z]+$ ]]; then
+  echo "Bad unique suffix format. Lowercase alphabet chars only."
+  exit 1
+fi
+
+mount="/tmp/fusor-test-mount-$1-$2"
 
 umount $mount 2> /dev/null


### PR DESCRIPTION
**Note**
This PR should be tested and merged in tandem with https://github.com/fusor/fusor/pull/1302 from fusor. 

**Change Description**
The purpose of this change is to give each storage designation (RHV, RHV Self-Hosted, Export, OCP) a unique test mount-point so that mount validations can run in parallel without risk of collision.

I've implemented this by adding a unique suffix to each test mount point (rhv, selfhosted, export, ocp).


**Testing Instructions**

1. Pull this PR and the PR from fusor into your dev env
2. Create a deployment with RHV, CFME, and OCP. 
3. Click back and forth on the "Storage" steps (RHV storage step, OCP storage step) and have the process run without failure, provided that your share info is valid.
4. Run the overall deployment validations by navigating to the "Review" step without errors